### PR TITLE
Fix some of the migrations

### DIFF
--- a/db/migrate/20140315002926_create_users.rb
+++ b/db/migrate/20140315002926_create_users.rb
@@ -1,5 +1,5 @@
-class CreateUsers < ActiveRecord::Migration
-  def change
+class CreateUsers < ActiveRecord::Migration[5.0]
+def change
     create_table :users do |t|
       t.string :name
       t.string :email

--- a/db/migrate/20140315112012_add_index_to_users_email.rb
+++ b/db/migrate/20140315112012_add_index_to_users_email.rb
@@ -1,5 +1,5 @@
-class AddIndexToUsersEmail < ActiveRecord::Migration
-  def change
+class AddIndexToUsersEmail < ActiveRecord::Migration[5.0]
+def change
     add_index :users, :email, unique: true
   end
 end

--- a/db/migrate/20140315112445_add_password_digest_to_users.rb
+++ b/db/migrate/20140315112445_add_password_digest_to_users.rb
@@ -1,5 +1,5 @@
-class AddPasswordDigestToUsers < ActiveRecord::Migration
-  def change
+class AddPasswordDigestToUsers < ActiveRecord::Migration[5.0]
+def change
     add_column :users, :password_digest, :string
   end
 end

--- a/db/migrate/20140315142240_add_remember_token_to_users.rb
+++ b/db/migrate/20140315142240_add_remember_token_to_users.rb
@@ -1,5 +1,5 @@
-class AddRememberTokenToUsers < ActiveRecord::Migration
-  def change
+class AddRememberTokenToUsers < ActiveRecord::Migration[5.0]
+def change
     add_column :users, :remember_token, :string
     add_index :users, :remember_token
 

--- a/db/migrate/20140317114830_add_admin_to_users.rb
+++ b/db/migrate/20140317114830_add_admin_to_users.rb
@@ -1,5 +1,5 @@
-class AddAdminToUsers < ActiveRecord::Migration
-  def change
+class AddAdminToUsers < ActiveRecord::Migration[5.0]
+def change
     add_column :users, :admin, :boolean, default: false
   end
 end

--- a/db/migrate/20140317121910_add_default_value_to_user_approved_attribute.rb
+++ b/db/migrate/20140317121910_add_default_value_to_user_approved_attribute.rb
@@ -1,4 +1,4 @@
-class AddDefaultValueToUserApprovedAttribute < ActiveRecord::Migration
+class AddDefaultValueToUserApprovedAttribute < ActiveRecord::Migration[5.0]
 def up
     change_column :users, :approved, :boolean, :default => false
 end

--- a/db/migrate/20140317153715_create_quotes.rb
+++ b/db/migrate/20140317153715_create_quotes.rb
@@ -1,5 +1,5 @@
-class CreateQuotes < ActiveRecord::Migration
-  def change
+class CreateQuotes < ActiveRecord::Migration[5.0]
+def change
     create_table :quotes do |t|
       t.string :text
       t.integer :user_id

--- a/db/migrate/20140324171716_add_poll_id_to_voting.rb
+++ b/db/migrate/20140324171716_add_poll_id_to_voting.rb
@@ -1,5 +1,0 @@
-class AddPollIdToVoting < ActiveRecord::Migration
-  def change
-        add_column :votes, :poll_id, :integer
-  end
-end

--- a/db/migrate/20140327150016_create_events.rb
+++ b/db/migrate/20140327150016_create_events.rb
@@ -1,5 +1,5 @@
-class CreateEvents < ActiveRecord::Migration
-  def change
+class CreateEvents < ActiveRecord::Migration[5.0]
+def change
     create_table :events do |t|
       t.string :beschrijving
 

--- a/db/migrate/20140327150929_create_signups.rb
+++ b/db/migrate/20140327150929_create_signups.rb
@@ -1,5 +1,5 @@
-class CreateSignups < ActiveRecord::Migration
-  def change
+class CreateSignups < ActiveRecord::Migration[5.0]
+def change
     create_table :signups do |t|
       t.integer :event_id
       t.integer :user_id

--- a/db/migrate/20140401002603_create_usergroups.rb
+++ b/db/migrate/20140401002603_create_usergroups.rb
@@ -1,5 +1,5 @@
-class CreateUsergroups < ActiveRecord::Migration
-  def change
+class CreateUsergroups < ActiveRecord::Migration[5.0]
+def change
     create_table :usergroups do |t|
 
       t.timestamps

--- a/db/migrate/20140404154732_add_name_to_usergroup.rb
+++ b/db/migrate/20140404154732_add_name_to_usergroup.rb
@@ -1,5 +1,5 @@
-class AddNameToUsergroup < ActiveRecord::Migration
-  def change
+class AddNameToUsergroup < ActiveRecord::Migration[5.0]
+def change
     add_column :usergroups, :name, :string
   end
 end

--- a/db/migrate/20140404155402_create_groups.rb
+++ b/db/migrate/20140404155402_create_groups.rb
@@ -1,5 +1,5 @@
-class CreateGroups < ActiveRecord::Migration
-  def change
+class CreateGroups < ActiveRecord::Migration[5.0]
+def change
     create_table :groups do |t|
       t.integer :user_id
       t.integer :group_id

--- a/db/migrate/20140417171656_add_title_date_to_events.rb
+++ b/db/migrate/20140417171656_add_title_date_to_events.rb
@@ -1,5 +1,5 @@
-class AddTitleDateToEvents < ActiveRecord::Migration
-  def change
+class AddTitleDateToEvents < ActiveRecord::Migration[5.0]
+def change
     add_column :events, :title, :string
     add_column :events, :date, :date
   end

--- a/db/migrate/20140421201835_create_reviews.rb
+++ b/db/migrate/20140421201835_create_reviews.rb
@@ -1,5 +1,5 @@
-class CreateReviews < ActiveRecord::Migration
-  def change
+class CreateReviews < ActiveRecord::Migration[5.0]
+def change
     create_table :reviews do |t|
       t.integer :beer_id
       t.integer :user_id

--- a/db/migrate/20140421203005_create_beers.rb
+++ b/db/migrate/20140421203005_create_beers.rb
@@ -1,5 +1,5 @@
-class CreateBeers < ActiveRecord::Migration
-  def change
+class CreateBeers < ActiveRecord::Migration[5.0]
+def change
     create_table :beers do |t|
       t.string :name
       t.string :soort

--- a/db/migrate/20140421203318_add_picture_to_beers.rb
+++ b/db/migrate/20140421203318_add_picture_to_beers.rb
@@ -1,5 +1,5 @@
-class AddPictureToBeers < ActiveRecord::Migration
-  def change
+class AddPictureToBeers < ActiveRecord::Migration[5.0]
+def change
     add_column :beers, :picture, :string
   end
 end

--- a/db/migrate/20140421223058_change_string_to_text_reviews.rb
+++ b/db/migrate/20140421223058_change_string_to_text_reviews.rb
@@ -1,5 +1,5 @@
-class ChangeStringToTextReviews < ActiveRecord::Migration
-  def up
+class ChangeStringToTextReviews < ActiveRecord::Migration[5.0]
+def up
     change_column :reviews, :description, :text
 end
 def down

--- a/db/migrate/20140422000145_add_info_to_beers.rb
+++ b/db/migrate/20140422000145_add_info_to_beers.rb
@@ -1,5 +1,5 @@
-class AddInfoToBeers < ActiveRecord::Migration
-  def change
+class AddInfoToBeers < ActiveRecord::Migration[5.0]
+def change
     add_column :beers, :percentage, :string
     add_column :beers, :brewer, :string
     add_column :beers, :country, :string

--- a/db/migrate/20140422000258_add_date_to_review.rb
+++ b/db/migrate/20140422000258_add_date_to_review.rb
@@ -1,5 +1,5 @@
-class AddDateToReview < ActiveRecord::Migration
-  def change
+class AddDateToReview < ActiveRecord::Migration[5.0]
+def change
     add_column :reviews, :proefdatum, :date
   end
 end

--- a/db/migrate/20140428115102_add_user_id_and_deadline_to_events.rb
+++ b/db/migrate/20140428115102_add_user_id_and_deadline_to_events.rb
@@ -1,5 +1,5 @@
-class AddUserIdAndDeadlineToEvents < ActiveRecord::Migration
-  def change
+class AddUserIdAndDeadlineToEvents < ActiveRecord::Migration[5.0]
+def change
     add_column :events, :user_id, :integer
     add_column :events, :deadline, :datetime
   end

--- a/db/migrate/20140706120217_add.rb
+++ b/db/migrate/20140706120217_add.rb
@@ -1,4 +1,4 @@
-class Add < ActiveRecord::Migration
-  def change
+class Add < ActiveRecord::Migration[5.0]
+def change
   end
 end

--- a/db/migrate/20140706120658_add_end_time_to_events.rb
+++ b/db/migrate/20140706120658_add_end_time_to_events.rb
@@ -1,5 +1,5 @@
-class AddEndTimeToEvents < ActiveRecord::Migration
-  def change
+class AddEndTimeToEvents < ActiveRecord::Migration[5.0]
+def change
     add_column :events, :end_time, :datetime
   end
 end

--- a/db/migrate/20140706124819_date_to_datetime_in_events.rb
+++ b/db/migrate/20140706124819_date_to_datetime_in_events.rb
@@ -1,5 +1,5 @@
-class DateToDatetimeInEvents < ActiveRecord::Migration
-  def change
+class DateToDatetimeInEvents < ActiveRecord::Migration[5.0]
+def change
 		change_column :events, :date, :datetime
   end
 end

--- a/db/migrate/20141024224811_create_meetings.rb
+++ b/db/migrate/20141024224811_create_meetings.rb
@@ -1,5 +1,5 @@
-class CreateMeetings < ActiveRecord::Migration
-  def change
+class CreateMeetings < ActiveRecord::Migration[5.0]
+def change
     create_table :meetings do |t|
       t.text :agenda
       t.text :notes

--- a/db/migrate/20141024234527_add_onderwerp_and_user_id_to_meetings.rb
+++ b/db/migrate/20141024234527_add_onderwerp_and_user_id_to_meetings.rb
@@ -1,5 +1,5 @@
-class AddOnderwerpAndUserIdToMeetings < ActiveRecord::Migration
-  def change
+class AddOnderwerpAndUserIdToMeetings < ActiveRecord::Migration[5.0]
+def change
     add_column :meetings, :onderwerp, :string
     add_column :meetings, :user_id, :integer
     add_column :meetings, :date, :datetime

--- a/db/migrate/20141025154621_create_public_pages.rb
+++ b/db/migrate/20141025154621_create_public_pages.rb
@@ -1,5 +1,5 @@
-class CreatePublicPages < ActiveRecord::Migration
-  def change
+class CreatePublicPages < ActiveRecord::Migration[5.0]
+def change
     create_table :public_pages do |t|
       t.text :content
       t.string :title

--- a/db/migrate/20141102180341_add_user_id_to_motion.rb
+++ b/db/migrate/20141102180341_add_user_id_to_motion.rb
@@ -1,5 +1,0 @@
-class AddUserIdToMotion < ActiveRecord::Migration
-  def change
-    add_column :motions, :user_id, :integer
-  end
-end

--- a/db/migrate/20141208214403_create_api_keys.rb
+++ b/db/migrate/20141208214403_create_api_keys.rb
@@ -1,5 +1,5 @@
-class CreateApiKeys < ActiveRecord::Migration
-  def change
+class CreateApiKeys < ActiveRecord::Migration[5.0]
+def change
     create_table :api_keys do |t|
       t.string :key
       t.integer :user_id

--- a/db/migrate/20150109232244_create_news.rb
+++ b/db/migrate/20150109232244_create_news.rb
@@ -1,5 +1,5 @@
-class CreateNews < ActiveRecord::Migration
-  def change
+class CreateNews < ActiveRecord::Migration[5.0]
+def change
     create_table :news do |t|
       t.string :cat
       t.text :body

--- a/db/migrate/20150110121305_add_user_id_to_news.rb
+++ b/db/migrate/20150110121305_add_user_id_to_news.rb
@@ -1,5 +1,5 @@
-class AddUserIdToNews < ActiveRecord::Migration
-  def change
+class AddUserIdToNews < ActiveRecord::Migration[5.0]
+def change
     add_column :news, :user_id, :integer
   end
 end

--- a/db/migrate/20150209224327_add_location_to_event.rb
+++ b/db/migrate/20150209224327_add_location_to_event.rb
@@ -1,5 +1,5 @@
-class AddLocationToEvent < ActiveRecord::Migration
-  def change
+class AddLocationToEvent < ActiveRecord::Migration[5.0]
+def change
     add_column :events, :location, :string
   end
 end

--- a/db/migrate/20150216152307_update_description_of_event.rb
+++ b/db/migrate/20150216152307_update_description_of_event.rb
@@ -1,5 +1,5 @@
-class UpdateDescriptionOfEvent < ActiveRecord::Migration
-	def up
+class UpdateDescriptionOfEvent < ActiveRecord::Migration[5.0]
+def up
 		change_table :events do |t|
 		  t.change :beschrijving, :text
 		end

--- a/db/migrate/20150601115705_create_devices.rb
+++ b/db/migrate/20150601115705_create_devices.rb
@@ -1,5 +1,5 @@
-class CreateDevices < ActiveRecord::Migration
-  def change
+class CreateDevices < ActiveRecord::Migration[5.0]
+def change
     create_table :devices do |t|
       t.integer :user_id
       t.string :device_key

--- a/db/migrate/20150609152649_create_pushes.rb
+++ b/db/migrate/20150609152649_create_pushes.rb
@@ -1,5 +1,5 @@
-class CreatePushes < ActiveRecord::Migration
-  def change
+class CreatePushes < ActiveRecord::Migration[5.0]
+def change
     create_table :pushes do |t|
       t.integer :user_id
       t.text :data

--- a/db/migrate/20150617132700_add_ur_lto_beer.rb
+++ b/db/migrate/20150617132700_add_ur_lto_beer.rb
@@ -1,5 +1,5 @@
-class AddUrLtoBeer < ActiveRecord::Migration
-  def change
+class AddUrLtoBeer < ActiveRecord::Migration[5.0]
+def change
 		add_column :beers, :URL, :string
   end
 end

--- a/db/migrate/20150623094333_create_api_logs.rb
+++ b/db/migrate/20150623094333_create_api_logs.rb
@@ -1,5 +1,5 @@
-class CreateApiLogs < ActiveRecord::Migration
-  def change
+class CreateApiLogs < ActiveRecord::Migration[5.0]
+def change
     create_table :api_logs do |t|
       t.string :ip_addr
       t.string :resource_call

--- a/db/migrate/20150623095026_add_key_to_api_log.rb
+++ b/db/migrate/20150623095026_add_key_to_api_log.rb
@@ -1,5 +1,5 @@
-class AddKeyToApiLog < ActiveRecord::Migration
-  def change
+class AddKeyToApiLog < ActiveRecord::Migration[5.0]
+def change
     add_column :api_logs, :key, :string
   end
 end

--- a/db/migrate/20150623120925_change_resource_to_text_in_api_log.rb
+++ b/db/migrate/20150623120925_change_resource_to_text_in_api_log.rb
@@ -1,6 +1,6 @@
-class ChangeResourceToTextInApiLog < ActiveRecord::Migration
-  class ChangeDateFormatInMyTable < ActiveRecord::Migration
-		  def up
+class ChangeResourceToTextInApiLog < ActiveRecord::Migration[5.0]
+class ChangeDateFormatInMyTable < ActiveRecord::Migration[5.0]
+def up
 				    change_column :api_logs, :resource_log, :text
 						  end
 

--- a/db/migrate/20150626070916_change_resource_log_to_text_in_api_log.rb
+++ b/db/migrate/20150626070916_change_resource_log_to_text_in_api_log.rb
@@ -1,5 +1,5 @@
-class ChangeResourceLogToTextInApiLog < ActiveRecord::Migration
-  def change
+class ChangeResourceLogToTextInApiLog < ActiveRecord::Migration[5.0]
+def change
 		reversible do |dir|
 			      change_table :api_logs do |t|
 							        dir.up   { t.change :resource_call, :text }

--- a/db/migrate/20150630074607_change_data_in_push_to_text.rb
+++ b/db/migrate/20150630074607_change_data_in_push_to_text.rb
@@ -1,5 +1,5 @@
-class ChangeDataInPushToText < ActiveRecord::Migration
-	def change
+class ChangeDataInPushToText < ActiveRecord::Migration[5.0]
+def change
 		reversible do |dir|
 			change_table :pushes do |t|
 				dir.up   { t.change :data, :text }

--- a/db/migrate/20150912153124_create_nicknames.rb
+++ b/db/migrate/20150912153124_create_nicknames.rb
@@ -1,5 +1,5 @@
-class CreateNicknames < ActiveRecord::Migration
-  def change
+class CreateNicknames < ActiveRecord::Migration[5.0]
+def change
     create_table :nicknames do |t|
       t.references :user, index: true, foreign_key: true
       t.string :nickname

--- a/db/migrate/20160404142409_add_batch_to_users.rb
+++ b/db/migrate/20160404142409_add_batch_to_users.rb
@@ -1,5 +1,5 @@
-class AddBatchToUsers < ActiveRecord::Migration
-  def change
+class AddBatchToUsers < ActiveRecord::Migration[5.0]
+def change
     add_column :users, :batch, :integer
   end
 end

--- a/db/migrate/20160417165036_create_images.rb
+++ b/db/migrate/20160417165036_create_images.rb
@@ -1,5 +1,5 @@
-class CreateImages < ActiveRecord::Migration
-  def change
+class CreateImages < ActiveRecord::Migration[5.0]
+def change
     create_table :images do |t|
       t.string :title
       t.string :image_id

--- a/db/migrate/20160417170150_create_albums.rb
+++ b/db/migrate/20160417170150_create_albums.rb
@@ -1,5 +1,5 @@
-class CreateAlbums < ActiveRecord::Migration
-  def change
+class CreateAlbums < ActiveRecord::Migration[5.0]
+def change
     create_table :albums do |t|
       t.string :title
       t.string :description

--- a/db/migrate/20160606105932_create_stickers.rb
+++ b/db/migrate/20160606105932_create_stickers.rb
@@ -1,5 +1,5 @@
-class CreateStickers < ActiveRecord::Migration
-  def change
+class CreateStickers < ActiveRecord::Migration[5.0]
+def change
     create_table :stickers do |t|
       t.string :lat
       t.string :lon

--- a/db/migrate/20160617191813_add_anonymous_to_users.rb
+++ b/db/migrate/20160617191813_add_anonymous_to_users.rb
@@ -1,5 +1,5 @@
-class AddAnonymousToUsers < ActiveRecord::Migration
-  def change
+class AddAnonymousToUsers < ActiveRecord::Migration[5.0]
+def change
     add_column :users, :anonymous, :boolean
   end
 end

--- a/db/migrate/20160620152227_add_deleted_at_to_quotes.rb
+++ b/db/migrate/20160620152227_add_deleted_at_to_quotes.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToQuotes < ActiveRecord::Migration
-  def change
+class AddDeletedAtToQuotes < ActiveRecord::Migration[5.0]
+def change
     add_column :quotes, :deleted_at, :datetime
     add_index :quotes, :deleted_at
   end

--- a/db/migrate/20160620152744_add_deleted_at_to_reviews.rb
+++ b/db/migrate/20160620152744_add_deleted_at_to_reviews.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToReviews < ActiveRecord::Migration
-  def change
+class AddDeletedAtToReviews < ActiveRecord::Migration[5.0]
+def change
     add_column :reviews, :deleted_at, :datetime
     add_index :reviews, :deleted_at
   end

--- a/db/migrate/20160620152755_add_deleted_at_to_beers.rb
+++ b/db/migrate/20160620152755_add_deleted_at_to_beers.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToBeers < ActiveRecord::Migration
-  def change
+class AddDeletedAtToBeers < ActiveRecord::Migration[5.0]
+def change
     add_column :beers, :deleted_at, :datetime
     add_index :beers, :deleted_at
   end

--- a/db/migrate/20160620152811_add_deleted_at_to_events.rb
+++ b/db/migrate/20160620152811_add_deleted_at_to_events.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToEvents < ActiveRecord::Migration
-  def change
+class AddDeletedAtToEvents < ActiveRecord::Migration[5.0]
+def change
     add_column :events, :deleted_at, :datetime
     add_index :events, :deleted_at
   end

--- a/db/migrate/20160620153020_add_deleted_at_to_stickers.rb
+++ b/db/migrate/20160620153020_add_deleted_at_to_stickers.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToStickers < ActiveRecord::Migration
-  def change
+class AddDeletedAtToStickers < ActiveRecord::Migration[5.0]
+def change
     add_column :stickers, :deleted_at, :datetime
     add_index :stickers, :deleted_at
   end

--- a/db/migrate/20160620153055_add_deleted_at_to_signups.rb
+++ b/db/migrate/20160620153055_add_deleted_at_to_signups.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToSignups < ActiveRecord::Migration
-  def change
+class AddDeletedAtToSignups < ActiveRecord::Migration[5.0]
+def change
     add_column :signups, :deleted_at, :datetime
     add_index :signups, :deleted_at
   end

--- a/db/migrate/20160620153105_add_deleted_at_to_news.rb
+++ b/db/migrate/20160620153105_add_deleted_at_to_news.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToNews < ActiveRecord::Migration
-  def change
+class AddDeletedAtToNews < ActiveRecord::Migration[5.0]
+def change
     add_column :news, :deleted_at, :datetime
     add_index :news, :deleted_at
   end

--- a/db/migrate/20160620153350_add_deleted_at_to_albums.rb
+++ b/db/migrate/20160620153350_add_deleted_at_to_albums.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToAlbums < ActiveRecord::Migration
-  def change
+class AddDeletedAtToAlbums < ActiveRecord::Migration[5.0]
+def change
     add_column :albums, :deleted_at, :datetime
     add_index :albums, :deleted_at
   end

--- a/db/migrate/20160620153359_add_deleted_at_to_api_keys.rb
+++ b/db/migrate/20160620153359_add_deleted_at_to_api_keys.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToApiKeys < ActiveRecord::Migration
-  def change
+class AddDeletedAtToApiKeys < ActiveRecord::Migration[5.0]
+def change
     add_column :api_keys, :deleted_at, :datetime
     add_index :api_keys, :deleted_at
   end

--- a/db/migrate/20160620153408_add_deleted_at_to_api_logs.rb
+++ b/db/migrate/20160620153408_add_deleted_at_to_api_logs.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToApiLogs < ActiveRecord::Migration
-  def change
+class AddDeletedAtToApiLogs < ActiveRecord::Migration[5.0]
+def change
     add_column :api_logs, :deleted_at, :datetime
     add_index :api_logs, :deleted_at
   end

--- a/db/migrate/20160620153427_add_deleted_at_to_devices.rb
+++ b/db/migrate/20160620153427_add_deleted_at_to_devices.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToDevices < ActiveRecord::Migration
-  def change
+class AddDeletedAtToDevices < ActiveRecord::Migration[5.0]
+def change
     add_column :devices, :deleted_at, :datetime
     add_index :devices, :deleted_at
   end

--- a/db/migrate/20160620153436_add_deleted_at_to_groups.rb
+++ b/db/migrate/20160620153436_add_deleted_at_to_groups.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToGroups < ActiveRecord::Migration
-  def change
+class AddDeletedAtToGroups < ActiveRecord::Migration[5.0]
+def change
     add_column :groups, :deleted_at, :datetime
     add_index :groups, :deleted_at
   end

--- a/db/migrate/20160620153456_add_deleted_at_to_images.rb
+++ b/db/migrate/20160620153456_add_deleted_at_to_images.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToImages < ActiveRecord::Migration
-  def change
+class AddDeletedAtToImages < ActiveRecord::Migration[5.0]
+def change
     add_column :images, :deleted_at, :datetime
     add_index :images, :deleted_at
   end

--- a/db/migrate/20160620153512_add_deleted_at_to_meetings.rb
+++ b/db/migrate/20160620153512_add_deleted_at_to_meetings.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToMeetings < ActiveRecord::Migration
-  def change
+class AddDeletedAtToMeetings < ActiveRecord::Migration[5.0]
+def change
     add_column :meetings, :deleted_at, :datetime
     add_index :meetings, :deleted_at
   end

--- a/db/migrate/20160620153521_add_deleted_at_to_motions.rb
+++ b/db/migrate/20160620153521_add_deleted_at_to_motions.rb
@@ -1,6 +1,0 @@
-class AddDeletedAtToMotions < ActiveRecord::Migration
-  def change
-    add_column :motions, :deleted_at, :datetime
-    add_index :motions, :deleted_at
-  end
-end

--- a/db/migrate/20160620153533_add_deleted_at_to_nicknames.rb
+++ b/db/migrate/20160620153533_add_deleted_at_to_nicknames.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToNicknames < ActiveRecord::Migration
-  def change
+class AddDeletedAtToNicknames < ActiveRecord::Migration[5.0]
+def change
     add_column :nicknames, :deleted_at, :datetime
     add_index :nicknames, :deleted_at
   end

--- a/db/migrate/20160620153557_add_deleted_at_to_public_pages.rb
+++ b/db/migrate/20160620153557_add_deleted_at_to_public_pages.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToPublicPages < ActiveRecord::Migration
-  def change
+class AddDeletedAtToPublicPages < ActiveRecord::Migration[5.0]
+def change
     add_column :public_pages, :deleted_at, :datetime
     add_index :public_pages, :deleted_at
   end

--- a/db/migrate/20160620153607_add_deleted_at_to_public_pushes.rb
+++ b/db/migrate/20160620153607_add_deleted_at_to_public_pushes.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToPublicPushes < ActiveRecord::Migration
-  def change
+class AddDeletedAtToPublicPushes < ActiveRecord::Migration[5.0]
+def change
     add_column :pushes, :deleted_at, :datetime
     add_index :pushes, :deleted_at
   end

--- a/db/migrate/20160620153625_add_deleted_at_to_public_users.rb
+++ b/db/migrate/20160620153625_add_deleted_at_to_public_users.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToPublicUsers < ActiveRecord::Migration
-  def change
+class AddDeletedAtToPublicUsers < ActiveRecord::Migration[5.0]
+def change
     add_column :users, :deleted_at, :datetime
     add_index :users, :deleted_at
   end

--- a/db/migrate/20160620153636_add_deleted_at_to_public_user_groups.rb
+++ b/db/migrate/20160620153636_add_deleted_at_to_public_user_groups.rb
@@ -1,5 +1,5 @@
-class AddDeletedAtToPublicUserGroups < ActiveRecord::Migration
-  def change
+class AddDeletedAtToPublicUserGroups < ActiveRecord::Migration[5.0]
+def change
     add_column :usergroups, :deleted_at, :datetime
     add_index :usergroups, :deleted_at
   end

--- a/db/migrate/20160804160803_add_grade_to_beers.rb
+++ b/db/migrate/20160804160803_add_grade_to_beers.rb
@@ -1,5 +1,5 @@
-class AddGradeToBeers < ActiveRecord::Migration
-  def change
+class AddGradeToBeers < ActiveRecord::Migration[5.0]
+def change
     add_column :beers, :grade, :double
   end
 end

--- a/db/migrate/20160804165516_add_weight_to_user.rb
+++ b/db/migrate/20160804165516_add_weight_to_user.rb
@@ -1,5 +1,5 @@
-class AddWeightToUser < ActiveRecord::Migration
-  def change
+class AddWeightToUser < ActiveRecord::Migration[5.0]
+def change
     add_column :users, :weight, :double, default: 0
   end
 end

--- a/db/migrate/20160917155621_create_emails.rb
+++ b/db/migrate/20160917155621_create_emails.rb
@@ -1,5 +1,5 @@
-class CreateEmails < ActiveRecord::Migration
-  def change
+class CreateEmails < ActiveRecord::Migration[5.0]
+def change
     create_table :emails do |t|
       t.string :from
       t.string :to

--- a/db/migrate/20161211131812_create_versions.rb
+++ b/db/migrate/20161211131812_create_versions.rb
@@ -1,7 +1,7 @@
 # This migration creates the `versions` table, the only schema PT requires.
 # All other migrations PT provides are optional.
-class CreateVersions < ActiveRecord::Migration
-  # Class names of MySQL adapters.
+class CreateVersions < ActiveRecord::Migration[5.0]
+# Class names of MySQL adapters.
   # - `MysqlAdapter` - Used by gems: `mysql`, `activerecord-jdbcmysql-adapter`.
   # - `Mysql2Adapter` - Used by `mysql2` gem.
   MYSQL_ADAPTERS = [

--- a/db/migrate/20161211173228_add_object_changes_to_versions.rb
+++ b/db/migrate/20161211173228_add_object_changes_to_versions.rb
@@ -1,8 +1,8 @@
 # This migration adds the optional `object_changes` column, in which PaperTrail
 # will store the `changes` diff for each update event. See the readme for
 # details.
-class AddObjectChangesToVersions < ActiveRecord::Migration
-  # The largest text column available in all supported RDBMS.
+class AddObjectChangesToVersions < ActiveRecord::Migration[5.0]
+# The largest text column available in all supported RDBMS.
   # See `create_versions.rb` for details.
   TEXT_BYTES = 1_073_741_823
 

--- a/db/migrate/20170318201506_add_rpush.rb
+++ b/db/migrate/20170318201506_add_rpush.rb
@@ -19,8 +19,8 @@
 # approach. The constituent parts of this migration have been executed
 # many times, by many people!
 
-class AddRpush < ActiveRecord::Migration
-  def self.migrations
+class AddRpush < ActiveRecord::Migration[5.0]
+def self.migrations
     [CreateRapnsNotifications, CreateRapnsFeedback,
      AddAlertIsJsonToRapnsNotifications, AddAppToRapns,
      CreateRapnsApps, AddGcm, AddWpns, AddAdm, RenameRapnsToRpush,
@@ -41,8 +41,8 @@ class AddRpush < ActiveRecord::Migration
     end
   end
 
-  class CreateRapnsNotifications < ActiveRecord::Migration
-    def self.up
+  class CreateRapnsNotifications < ActiveRecord::Migration[5.0]
+def self.up
       create_table :rapns_notifications do |t|
         t.integer   :badge,                 null: true
         t.string    :device_token,          null: false, limit: 64
@@ -64,15 +64,15 @@ class AddRpush < ActiveRecord::Migration
     end
 
     def self.down
-      if index_name_exists?(:rapns_notifications, 'index_rapns_notifications_multi', true)
+      if index_name_exists?(:rapns_notifications, 'index_rapns_notifications_multi')
         remove_index :rapns_notifications, name: 'index_rapns_notifications_multi'
       end
       drop_table :rapns_notifications
     end
   end
 
-  class CreateRapnsFeedback < ActiveRecord::Migration
-    def self.up
+  class CreateRapnsFeedback < ActiveRecord::Migration[5.0]
+def self.up
       create_table :rapns_feedback do |t|
         t.string    :device_token,          null: false, limit: 64
         t.timestamp :failed_at,             null: false
@@ -83,15 +83,15 @@ class AddRpush < ActiveRecord::Migration
     end
 
     def self.down
-      if index_name_exists?(:rapns_feedback, :index_rapns_feedback_on_device_token, true)
+      if index_name_exists?(:rapns_feedback, :index_rapns_feedback_on_device_token)
         remove_index :rapns_feedback, name: :index_rapns_feedback_on_device_token
       end
       drop_table :rapns_feedback
     end
   end
 
-  class AddAlertIsJsonToRapnsNotifications < ActiveRecord::Migration
-    def self.up
+  class AddAlertIsJsonToRapnsNotifications < ActiveRecord::Migration[5.0]
+def self.up
       add_column :rapns_notifications, :alert_is_json, :boolean, null: true, default: false
     end
 
@@ -100,8 +100,8 @@ class AddRpush < ActiveRecord::Migration
     end
   end
 
-  class AddAppToRapns < ActiveRecord::Migration
-    def self.up
+  class AddAppToRapns < ActiveRecord::Migration[5.0]
+def self.up
       add_column :rapns_notifications, :app, :string, null: true
       add_column :rapns_feedback, :app, :string, null: true
     end
@@ -112,8 +112,8 @@ class AddRpush < ActiveRecord::Migration
     end
   end
 
-  class CreateRapnsApps < ActiveRecord::Migration
-    def self.up
+  class CreateRapnsApps < ActiveRecord::Migration[5.0]
+def self.up
       create_table :rapns_apps do |t|
         t.string    :key,             null: false
         t.string    :environment,     null: false
@@ -129,8 +129,8 @@ class AddRpush < ActiveRecord::Migration
     end
   end
 
-  class AddGcm < ActiveRecord::Migration
-    module Rapns
+  class AddGcm < ActiveRecord::Migration[5.0]
+module Rapns
       class App < ActiveRecord::Base
         self.table_name = 'rapns_apps'
       end
@@ -181,9 +181,9 @@ class AddRpush < ActiveRecord::Migration
       change_column :rapns_notifications, :app_id, :integer, null: false
       remove_column :rapns_notifications, :app
 
-      if index_name_exists?(:rapns_notifications, "index_rapns_notifications_multi", true)
+      if index_name_exists?(:rapns_notifications, "index_rapns_notifications_multi")
         remove_index :rapns_notifications, name: "index_rapns_notifications_multi"
-      elsif index_name_exists?(:rapns_notifications, "index_rapns_notifications_on_delivered_failed_deliver_after", false)
+      elsif index_name_exists?(:rapns_notifications, "index_rapns_notifications_on_delivered_failed_deliver_after")
         remove_index :rapns_notifications, name: "index_rapns_notifications_on_delivered_failed_deliver_after"
       end
       add_index :rapns_notifications, [:app_id, :delivered, :failed, :deliver_after], name: "index_rapns_notifications_multi"
@@ -222,7 +222,7 @@ class AddRpush < ActiveRecord::Migration
         AddGcm::Rapns::Notification.where(app_id: app.id).update_all(app: app.key)
       end
 
-      if index_name_exists?(:rapns_notifications, :index_rapns_notifications_multi, true)
+      if index_name_exists?(:rapns_notifications, :index_rapns_notifications_multi)
           remove_index :rapns_notifications, name: :index_rapns_notifications_multi
       end
 
@@ -232,8 +232,8 @@ class AddRpush < ActiveRecord::Migration
     end
   end
 
-  class AddWpns < ActiveRecord::Migration
-    module Rapns
+  class AddWpns < ActiveRecord::Migration[5.0]
+module Rapns
       class Notification < ActiveRecord::Base
         self.table_name = 'rapns_notifications'
       end
@@ -249,8 +249,8 @@ class AddRpush < ActiveRecord::Migration
     end
   end
 
-  class AddAdm < ActiveRecord::Migration
-    module Rapns
+  class AddAdm < ActiveRecord::Migration[5.0]
+module Rapns
       class Notification < ActiveRecord::Base
         self.table_name = 'rapns_notifications'
       end
@@ -273,8 +273,8 @@ class AddRpush < ActiveRecord::Migration
     end
   end
 
-  class RenameRapnsToRpush < ActiveRecord::Migration
-    module Rpush
+  class RenameRapnsToRpush < ActiveRecord::Migration[5.0]
+module Rpush
       class App < ActiveRecord::Base
         self.table_name = 'rpush_apps'
       end
@@ -293,11 +293,11 @@ class AddRpush < ActiveRecord::Migration
       rename_table :rapns_apps, :rpush_apps
       rename_table :rapns_feedback, :rpush_feedback
 
-      if index_name_exists?(:rpush_notifications, :index_rapns_notifications_multi, true)
+      if index_name_exists?(:rpush_notifications, :index_rapns_notifications_multi)
         rename_index :rpush_notifications, :index_rapns_notifications_multi, :index_rpush_notifications_multi
       end
 
-      if index_name_exists?(:rpush_feedback, :index_rapns_feedback_on_device_token, true)
+      if index_name_exists?(:rpush_feedback, :index_rapns_feedback_on_device_token)
         rename_index :rpush_feedback, :index_rapns_feedback_on_device_token, :index_rpush_feedback_on_device_token
       end
 
@@ -323,11 +323,11 @@ class AddRpush < ActiveRecord::Migration
       update_type(RenameRapnsToRpush::Rpush::App, 'Rpush::Adm::App', 'Rapns::Adm::App')
       update_type(RenameRapnsToRpush::Rpush::App, 'Rpush::Wpns::App', 'Rapns::Wpns::App')
 
-      if index_name_exists?(:rpush_notifications, :index_rpush_notifications_multi, true)
+      if index_name_exists?(:rpush_notifications, :index_rpush_notifications_multi)
         rename_index :rpush_notifications, :index_rpush_notifications_multi, :index_rapns_notifications_multi
       end
 
-      if index_name_exists?(:rpush_feedback, :index_rpush_feedback_on_device_token, true)
+      if index_name_exists?(:rpush_feedback, :index_rpush_feedback_on_device_token)
         rename_index :rpush_feedback, :index_rpush_feedback_on_device_token, :index_rapns_feedback_on_device_token
       end
 
@@ -337,8 +337,8 @@ class AddRpush < ActiveRecord::Migration
     end
   end
 
-  class AddFailAfterToRpushNotifications < ActiveRecord::Migration
-    def self.up
+  class AddFailAfterToRpushNotifications < ActiveRecord::Migration[5.0]
+def self.up
       add_column :rpush_notifications, :fail_after, :timestamp, null: true
     end
 

--- a/db/migrate/20170318201507_rpush_2_0_0_updates.rb
+++ b/db/migrate/20170318201507_rpush_2_0_0_updates.rb
@@ -1,5 +1,5 @@
-class Rpush200Updates < ActiveRecord::Migration
-  module Rpush
+class Rpush200Updates < ActiveRecord::Migration[5.0]
+module Rpush
     class App < ActiveRecord::Base
       self.table_name = 'rpush_apps'
     end
@@ -17,7 +17,7 @@ class Rpush200Updates < ActiveRecord::Migration
     add_column :rpush_notifications, :processing, :boolean, null: false, default: false
     add_column :rpush_notifications, :priority, :integer, null: true
 
-    if index_name_exists?(:rpush_notifications, :index_rpush_notifications_multi, true)
+    if index_name_exists?(:rpush_notifications, :index_rpush_notifications_multi)
       remove_index :rpush_notifications, name: :index_rpush_notifications_multi
     end
 
@@ -46,7 +46,7 @@ class Rpush200Updates < ActiveRecord::Migration
     change_column :rpush_feedback, :app_id, :string
     rename_column :rpush_feedback, :app_id, :app
 
-    if index_name_exists?(:rpush_notifications, :index_rpush_notifications_multi, true)
+    if index_name_exists?(:rpush_notifications, :index_rpush_notifications_multi)
       remove_index :rpush_notifications, name: :index_rpush_notifications_multi
     end
 

--- a/db/migrate/20170318201508_rpush_2_1_0_updates.rb
+++ b/db/migrate/20170318201508_rpush_2_1_0_updates.rb
@@ -1,5 +1,5 @@
-class Rpush210Updates < ActiveRecord::Migration
-  def self.up
+class Rpush210Updates < ActiveRecord::Migration[5.0]
+def self.up
     add_column :rpush_notifications, :url_args, :text, null: true
     add_column :rpush_notifications, :category, :string, null: true
   end

--- a/db/migrate/20170318201509_rpush_2_6_0_updates.rb
+++ b/db/migrate/20170318201509_rpush_2_6_0_updates.rb
@@ -1,5 +1,5 @@
-class Rpush260Updates < ActiveRecord::Migration
-  def self.up
+class Rpush260Updates < ActiveRecord::Migration[5.0]
+def self.up
     add_column :rpush_notifications, :content_available, :boolean, default: false
   end
 

--- a/db/migrate/20170318201510_rpush_2_7_0_updates.rb
+++ b/db/migrate/20170318201510_rpush_2_7_0_updates.rb
@@ -1,5 +1,5 @@
-class Rpush270Updates < ActiveRecord::Migration
-  def self.up
+class Rpush270Updates < ActiveRecord::Migration[5.0]
+def self.up
     change_column :rpush_notifications, :alert, :text
     add_column :rpush_notifications, :notification, :text
   end

--- a/db/migrate/20170525210915_add_attachment_image_to_stickers.rb
+++ b/db/migrate/20170525210915_add_attachment_image_to_stickers.rb
@@ -1,5 +1,5 @@
-class AddAttachmentImageToStickers < ActiveRecord::Migration
-  def self.up
+class AddAttachmentImageToStickers < ActiveRecord::Migration[5.0]
+def self.up
     change_table :stickers do |t|
       t.attachment :image
     end

--- a/db/migrate/20170530170915_add_attachment_image_to_blogphotos.rb
+++ b/db/migrate/20170530170915_add_attachment_image_to_blogphotos.rb
@@ -1,5 +1,5 @@
-class AddAttachmentImageToBlogphotos < ActiveRecord::Migration
-  def self.up
+class AddAttachmentImageToBlogphotos < ActiveRecord::Migration[5.0]
+def self.up
     change_table :blogphotos do |t|
       t.attachment :image
     end


### PR DESCRIPTION
Unfortunately, running the migrations on an empty database fails.

It starts with the following error:
```
Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateUsers < ActiveRecord::Migration[4.2]
/home/kennedy/src/hamers/db/migrate/20140315002926_create_users.rb:1:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
```

These errors are circumvented by adding `[5.0]` to the migrations that were missing a version number.

Furthermore, some migrations were modified to remove the deprecated `default` argument from `index_name_exists?`. See: https://github.com/rails/rails/commit/8f5b34df81175e30f68879479243fbce966122d7

Still, the migrations will not run completely. The fix for the other migrations will be published in a separate pull request.