### PR TITLE
regex voor stickers fixen. Min mag ook

### DIFF
--- a/app/models/sticker.rb
+++ b/app/models/sticker.rb
@@ -3,8 +3,8 @@ class Sticker < ActiveRecord::Base
   has_attached_file :image
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\z/
   acts_as_paranoid
-  validates :lat, presence: true, format: { with: /(\d*\.\d*)/i, message: "Gast, dit is geen coördinaat"}
-  validates :lon, presence: true, format: { with: /(\d*\.\d*)/i, message: "Gast, dit is geen coördinaat"}
+  validates :lat, presence: true, format: { with: /\A(-?\d*\.\d*)\z/i, message: "Gast, dit is geen coördinaat"}
+  validates :lon, presence: true, format: { with: /\A(-?\d*\.\d*)\z/i, message: "Gast, dit is geen coördinaat"}
   def as_json(options)
     super({ only: %i[id lat lon notes user_id] }.merge(options))
   end

--- a/app/views/stickers/_form.html.erb
+++ b/app/views/stickers/_form.html.erb
@@ -1,12 +1,12 @@
 <%= form_for @sticker do |f| %>
   <div class="form-group">
     <%= f.label :lat %>
-    <%= f.text_field :lat, id: 'lat', class: 'form-control', pattern: '\d*\.\d*', required: true %>
+    <%= f.text_field :lat, id: 'lat', class: 'form-control', pattern: '-?\d*\.\d*', required: true %>
     <%= @sticker.errors.full_messages_for(:lat).first[3..] if @sticker.errors[:lat].any? %>
   </div>
   <div class="form-group">
     <%= f.label :lon %>
-    <%= f.text_field :lon, id: 'lon', class: 'form-control', pattern: '\d*\.\d*', required: true %>
+    <%= f.text_field :lon, id: 'lon', class: 'form-control', pattern: '-?\d*\.\d*', required: true %>
     <%= @sticker.errors.full_messages_for(:lon).first[3..] if @sticker.errors[:lon].any?  %>
   </div>
   <div class="form-group">


### PR DESCRIPTION
Min toegevoegd voor de regex voor coördinaten + de serverside-validate controleerde of de string een coördinaat containde. er moest een begin (\A) en eind (\z) omheen.