### PR TITLE
Use plain instead of action text

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,7 +17,7 @@ class Event < ActiveRecord::Base
     event.dtstart = date.strftime('%Y%m%dT%H%M%S')
     event.dtend = end_time.strftime('%Y%m%dT%H%M%S')
     event.summary = title
-    event.description = description || beschrijving
+    event.description = description.to_plain_text || beschrijving
     event.location = location
     event.ip_class = 'PUBLIC'
     event.url = "http://zondersikkel.nl/events/#{self.id}"


### PR DESCRIPTION
Vervangt de actiontext in het event zodat de iCal weer gegenereerd kan worden.