### PR TITLE
Remove user switcher from production

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -55,7 +55,9 @@
                   <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu">
-                  <li>Andere gebruiker: <%= switch_user_select class: 'btn btn-dropdown-toggle' %></li>
+                  <% if Rails.env.development? %>
+                    <li>Andere gebruiker: <%= switch_user_select class: 'btn btn-dropdown-toggle' %></li>
+                  <% end %>
                   <li><%= link_to 'OAuth-applicaties', oauth_applications_path %></li>
                   <li><%= link_to 'Download database dump', dbdump_path %></li>
                   <% if Rails.env.development? %>


### PR DESCRIPTION
De user switcher "<%= switch_user_select class: 'btn btn-dropdown-toggle' %>" is alleen beschikbaar op development. De context daaromheen niet. Daarom staat er nu een rare regel in de header die daar eigenlijk alleen in development thuishoort. Dit is nu opgelost door ook de context alleen in development te renderen.