### PR TITLE
Run drink cron at 1200 instead of 0000

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,11 +1,12 @@
 set :chronic_options, hours24: true
 
-every :monday, at: "0000" do
+every :monday, at: "1200" do
   # Use any day of the week or :weekend, :weekday
   runner "Event.new(beschrijving: \"Maandag, wellicht de mooiste dag van de week. Voor sommigen de dag van God, maar voor ons voornamelijk de dag van bier! Na enkele weken onder de tyrannie van slecht gespelde evenementen is ook deze automatische uitnodiging danig ververst, dat het er fatsoenlijk uitziet. Wij moeten er ook fatsoenlijk uitzien, dus overhemd aan en naar de Vluchte!\",
                     attendance: true, title: \"Maandagborrel\",
                     date: Time.now + 1.weeks + 9.hours,
-                    deadline: Time.now + 6.days + 6.hours, end_time: Time.now + 1.weeks + 14.hours,
+                    deadline: Time.now + 6.days + 6.hours,
+                    end_time: Time.now + 1.weeks + 14.hours,
                     location: \"De Vluchte Enschede\"
           ).save"
 end


### PR DESCRIPTION
Zodat de tijden van de borrel weer kloppen. Is misgegaan bij de conversie van am/pm naar 24-uurs.