### PR TITLE
Speed up event index page

### DIFF
--- a/app/models/signup.rb
+++ b/app/models/signup.rb
@@ -10,8 +10,10 @@ class Signup < ActiveRecord::Base
   scope :with_user, -> { includes(:user) }
 
   private
+
   def event_deadline_has_passed
-    errors.add(:event_id, "Event deadline has already passed") if
-      DateTime.now > Event.find(self.event_id).deadline
+    return unless DateTime.now > Event.find(self.event_id).deadline
+
+    errors.add(:event_id, "Event deadline has already passed")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,12 +26,10 @@ remember_token unconfirmed_email failed_attempts unlock_token locked_at weight u
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, format: {with: VALID_EMAIL_REGEX}, uniqueness: { case_sensitive: false }
 
-  default_scope { includes(:groups, :usergroups) }
-
   scope :leden, -> { joins(:groups).where(groups: { group_id: 4 }) }
   scope :aspiranten, -> { joins(:groups).where(groups: { group_id: 5 }) }
   scope :oud, -> { joins(:groups).where(groups: { group_id: 12 }) }
-  scope :extern, -> { where.not(id: Group.where(group_id: [4, 5, 12]).pluck(:user_id).uniq) }
+  scope :extern, -> { where.not(id: Group.where(group_id: [4, 5, 12]).select(:user_id).uniq) }
 
   def anonymize
     devices.destroy_all


### PR DESCRIPTION
Door niet meer in de user de default scope ook de uaergroups te laten ophalen hebben we op pagina's met veel users ongeveer de helft queries minder. Dit levert vooral op de index events pagina een behoorlijke tijdwinst op. 