### PR TITLE
Fix initial flatpickr dates

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -42,7 +42,7 @@
                              flatpickr_default_date: @event.date.strftime("%d-%m-%Y %H:%i"),
                              flatpickr_date_format: "d-m-Y H:i",
                              flatpickr_enable_time: true,
-                             flatpickr_time_24hr: true,
+                             flatpickr_time_24hr: true
                            } %>
         </div>
       </div>


### PR DESCRIPTION
`min_date` weggehaald omdat het aanpassen van activiteiten in het verleden ook mogelijk moet zijn.