### PR TITLE
Install webrick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'therubyracer'
 gem 'tzinfo'
 gem 'uglifier'
 gem 'web-console'
+gem 'webrick'
 gem "webpacker"
 gem 'will_paginate'
 gem 'wine_bouncer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,6 +327,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -389,9 +390,10 @@ DEPENDENCIES
   uglifier
   web-console
   webpacker
+  webrick
   whenever
   will_paginate
   wine_bouncer
 
 BUNDLED WITH
-   2.1.4
+   2.2.22


### PR DESCRIPTION
Since Ruby 3.0, webrick is not included by default anymore.