### PR TITLE
Rename actiontext_notes to notes

### DIFF
--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -25,7 +25,7 @@ class MeetingsController < ApplicationController
 
   def notuleer
     if (draft = @meeting.drafts.where(user: current_user).take)
-      @meeting.actiontext_notes = draft.rich_data
+      @meeting.notes = draft.rich_data
     end
 
     breadcrumb @meeting.onderwerp, meeting_path(@meeting)
@@ -40,7 +40,7 @@ class MeetingsController < ApplicationController
   def update
     respond_to do |format|
       if params[:commit] == "Opslaan"
-        @meeting.actiontext_notes = meeting_params[:actiontext_notes]
+        @meeting.notes = meeting_params[:notes]
         if @meeting.save
           format.html {redirect_to @meeting, notice: 'Vergadering is geüpdate.'}
         else
@@ -51,7 +51,7 @@ class MeetingsController < ApplicationController
         format.html {redirect_to @meeting, notice: "Concept is verwijderd."}
       elsif params[:commit] == "Verstuur"
         format.html do
-          @meeting.attributes = meeting_params.except(:actiontext_notes)
+          @meeting.attributes = meeting_params.except(:notes)
           if @meeting.save
             redirect_to(@meeting, notice: 'Vergadering is geüpdate.')
           else

--- a/app/helpers/params_helper.rb
+++ b/app/helpers/params_helper.rb
@@ -52,7 +52,7 @@ module ParamsHelper
   end
 
   def meeting_params
-    params.require(:meeting).permit(:agenda, :onderwerp, :date, :actiontext_notes, :chairman_id, :secretary_id, user_ids: [])
+    params.require(:meeting).permit(:agenda, :onderwerp, :date, :notes, :chairman_id, :secretary_id, user_ids: [])
   end
 
   def sticker_params

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -9,8 +9,14 @@ class Meeting < ActiveRecord::Base
   has_many :drafts, as: :entity, dependent: :destroy
 
   has_rich_text :actiontext_notes
+  has_rich_text :notes
+
+  before_save do
+    self.notes = self.actiontext_notes
+    self.actiontext_notes.destroy
+  end
 
   def save_draft(user)
-    drafts.find_or_create_by(user: user).update(rich_data: actiontext_notes)
+    drafts.find_or_create_by(user: user).update(rich_data: notes)
   end
 end

--- a/app/views/meetings/notuleer.html.erb
+++ b/app/views/meetings/notuleer.html.erb
@@ -17,7 +17,7 @@
 
   <div class="form-group">
     <%= f.label :notes %><br>
-    <%= f.rich_text_area :actiontext_notes, class: 'form-control higher', data: {action: 'keyup->autosave#save'} %>
+    <%= f.rich_text_area :notes, class: 'form-control higher', data: {action: 'keyup->autosave#save'} %>
   </div>
   <div class="actions">
     <div class="btn-group">

--- a/app/views/meetings/show.html.erb
+++ b/app/views/meetings/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <div class="row">
   <div class="col-md-8">
-    <%= @meeting.actiontext_notes %>
+    <%= @meeting.notes %>
   </div>
   <div class="col-md-4 info-panel">
     <div class="panel panel-default">


### PR DESCRIPTION
Nu dat we de `notes`-kolom op meetings niet meer hebben, kunnen we actiontext_notes hernoemen naar notes zonder overlap.

Na het deployen van deze code kan op alle meetings `save!` gecalled worden en daarna kan deze code weer weg.