### PR TITLE
Hamers logo aspect ratio

### DIFF
--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -97,7 +97,7 @@
               <div>
                 <button type="button" class="max-w-xs bg-gray-800 rounded-full flex items-center text-sm focus:outline-none focus:ring-2 focus:ring-hamers-yellow-500" data-action="click->dropdown#toggle click@window->dropdown#hide" id="user-menu">
                   <span class="sr-only">Open user menu</span>
-                  <%= gravatar_for current_user, class: "h-10 w-10 rounded-full" %>
+                  <%= gravatar_for current_user, class: "h-8 w-8 rounded-full" %>
                 </button>
               </div>
 


### PR DESCRIPTION
Voor afbeeldingen die niet rond zijn kunnen we beter geen breedte meegeven (of geen hoogte), dan blijft goede ratio behouden en is hij goed scherp.

Heb verder de afbeelding een klein beetje groter gemaakt.