### PR TITLE
Merge master <- ics_event_end_date Fixes nil end_date for ics activities. Fixes #453

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,10 +22,10 @@ class Event < ActiveRecord::Base
     event = Icalendar::Event.new
     event.dtstart = date.strftime('%Y%m%dT%H%M%S')
     if end_time.nil?
-      event.dtend = end_time.strftime('%Y%m%dT%H%M%S')
-    else
       # standard endtime is + one hour for activities, since an endtime has to be defined within an ics activity and not on our site
       event.dtend = (date + 1.hour).strftime('%Y%m%dT%H%M%S')
+    else
+      event.dtend = end_time.strftime('%Y%m%dT%H%M%S')
     end
     event.summary = title
     event.description = "#{description.to_plain_text} \n\n #{url}"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,7 +21,12 @@ class Event < ActiveRecord::Base
     url = "https://zondersikkel.nl/events/#{self.id}"
     event = Icalendar::Event.new
     event.dtstart = date.strftime('%Y%m%dT%H%M%S')
-    event.dtend = end_time.strftime('%Y%m%dT%H%M%S')
+    if end_time.nil?
+      event.dtend = end_time.strftime('%Y%m%dT%H%M%S')
+    else
+      # standard endtime is + one hour for activities, since an endtime has to be defined within an ics activity and not on our site
+      event.dtend = (date + 1.hour).strftime('%Y%m%dT%H%M%S')
+    end
     event.summary = title
     event.description = "#{description.to_plain_text} \n\n #{url}"
     event.location = location

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,6 +11,7 @@ class Event < ActiveRecord::Base
   belongs_to :usergroup
   validates :title, presence: true, allow_blank: false
   validates :date, presence: true, allow_blank: false
+  validate :begin_before_end_time
 
   scope :with_signups, -> { includes(:signups) }
   scope :upcoming, -> { where(['date >= ?', Time.zone.now]) }
@@ -71,5 +72,12 @@ class Event < ActiveRecord::Base
 
   def to_s
     title
+  end
+
+  private
+
+  def begin_before_end_time
+    return unless date && end_time
+    errors.add(:end_time, 'De activiteit eindigt voordat hij begint.') if date > end_time
   end
 end


### PR DESCRIPTION
The end_time of any activity on our site does not have to be defined. We want to keep it that way, but ical events require an enddate for an event once a begindate is set. 
Therefore, if an endtime is **not** defined, we declare it as original time with an additional hour, as many standard calendars do. 
Another fix is that it was possible to for the endtime to be before the begintime. This issue has now been resolved.