### PR TITLE
Fixes #463

### DIFF
--- a/app/controllers/chugtypes_controller.rb
+++ b/app/controllers/chugtypes_controller.rb
@@ -36,7 +36,6 @@ class ChugtypesController < ApplicationController
   end
 
   def destroy
-    @chugtype.chugs.each { |chug| chug.destroy }
     delete_object(@chugtype)
   end
 

--- a/app/controllers/chugtypes_controller.rb
+++ b/app/controllers/chugtypes_controller.rb
@@ -36,6 +36,7 @@ class ChugtypesController < ApplicationController
   end
 
   def destroy
+    @chugtype.chugs.each { |chug| chug.destroy }
     delete_object(@chugtype)
   end
 

--- a/app/models/chugtype.rb
+++ b/app/models/chugtype.rb
@@ -2,7 +2,7 @@ class Chugtype < ActiveRecord::Base
   acts_as_paranoid
   has_paper_trail
   has_rich_text :description
-  has_many :chugs
+  has_many :chugs, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
   validates :amount, presence: true, numericality: { greater_than: 0 }

--- a/app/presenters/trail_presenter.rb
+++ b/app/presenters/trail_presenter.rb
@@ -75,7 +75,7 @@ class TrailPresenter
     when "Chugtype"
       "maakte adtcategorie <i>#{lookup_object.name}</i> - #{lookup_object.amount}ml"
     when "Chug"
-      "trok een #{lookup_object.chugtype.name.downcase} die #{lookup_object.time.round(2)}s duurde"
+      "trok een #{lookup_object.chugtype.nil? ? "een ad" : lookup_object.chugtype.name.downcase} die #{lookup_object.time.round(2)}s duurde"
     else
       "maakte #{type}"
     end
@@ -97,7 +97,7 @@ class TrailPresenter
     when "Chugtype"
       "wijzigde adtcategorie <i>#{lookup_object.name}</i> - #{lookup_object.amount}ml"
     when "Chug"
-      "wijzigde een adt van een #{lookup_object.chugtype.name.downcase} die #{lookup_object.time.round(2)}s duurde"
+      "wijzigde een adt van een #{lookup_object.chugtype.nil? ? "een ad" : lookup_object.chugtype.name.downcase} die #{lookup_object.time.round(2)}s duurde"
     when "ActionText::RichText"
       "wijzigde #{action_text_title}"
     when "User"
@@ -128,7 +128,7 @@ class TrailPresenter
     when "Chugtype"
       "verwijderde adtcategorie <i>#{lookup_object.name}</i> - #{lookup_object.amount}ml"
     when "Chug"
-      "verwijderde #{lookup_object.chugtype.name.downcase} die #{lookup_object.time.round(2)}s duurde"
+      "verwijderde #{lookup_object.chugtype.nil? ? "een ad" : lookup_object.chugtype.name.downcase} die #{lookup_object.time.round(2)}s duurde"
     else
       "verwijderde #{type}"
     end
@@ -171,7 +171,7 @@ class TrailPresenter
     when "Draft"
       "conceptnotulen"
     when "Chug"
-      "#{lookup_object.chugtype.name.downcase} die #{lookup_object.time.round(2)}s duurde"
+      "#{lookup_object.chugtype.nil? ? "een ad" : lookup_object.chugtype.name.downcase} die #{lookup_object.time.round(2)}s duurde"
     when "Chugtype"
       "adtcategorie <i>#{lookup_object.name}</i> - #{lookup_object.amount}ml"
     else

--- a/app/views/chugtypes/show.html.erb
+++ b/app/views/chugtypes/show.html.erb
@@ -25,8 +25,7 @@
 
 <div class="divide-y divide-gray-200 -my-6 md:grid md:grid-cols-12 md:divide-y-0 md:divide-x">
   <aside class="ml-6 py-6 md:col-span-4 md:pr-6">
-    Ben jij de volgende die een <%= @chugtype.name.downcase %> van <%= @chugtype.amount %> ml in één keer leeg gaat
-    trekken?
+    Ben jij de volgende die een <%= @chugtype.name.downcase %> van <%= @chugtype.amount %> ml in één keer leeg gaat trekken?
     <div class="flex justify-center mt-5 -ml-8">
       <%= button_to "Adt!", new_chug_path(@chugtype), method: :get, class: submit_classes %>
     </div>


### PR DESCRIPTION
Deletes chugs when chugtype is deleted.
Closes #463 because the error originates from the trail. Now checks if chugtype exists and if not replaces it with 'een ad'. 