### PR TITLE
Fix stickers

### DIFF
--- a/app/views/stickers/index.html.erb
+++ b/app/views/stickers/index.html.erb
@@ -31,7 +31,7 @@
       icon: '<%= image_path "pin.png" %>',
       map: map,
       optimized: false,
-      title: <% if s.notes.empty? %>'Sticker #<%= s.id %>'<% else %>'<%= s.notes %>'<% end %>,
+      title: <% if s.notes.empty? %>'Sticker #<%= s.id %>'<% else %>'<%= s.notes.gsub(/\n/, ' ') %>'<% end %>,
     });
     <% end %>
   }

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -4,7 +4,7 @@ SecureHeaders::Configuration.default do |config|
     httponly: true
   }
   config.csp = {
-    default_src: %w('self' www.google.com),
+    default_src: %w('self' www.google.com maps.googleapis.com),
     base_uri: %w('self'),
     img_src: %w(* data:),
     script_src: %w('self' 'unsafe-inline' www.google.com www.gstatic.com maps.googleapis.com cdnjs.cloudflare.com),


### PR DESCRIPTION
1. Fix de CSP header voor google maps. Persoonlijk kreeg ik een grijze kaart omdat bepaalde requests naar `maps.googleapis.com` geblokkeerd werden. Onderstaand plaatje krijg ik op https://zondersikkel.nl/stickers:
![pngout](https://github.com/DispuutHamers/webapp/assets/16014817/0805feb5-0ba1-4a07-9110-94ba11d1e644)
2. Strip newlines uit de sticker notes als ze in een Marker worden gestopt.

