### PR TITLE
Login failure message

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,6 @@
 class SessionsController < Devise::SessionsController
   def create
     self.resource = warden.authenticate(auth_options)
-    puts "#{auth_options} #{warden.inspect} #{warden.authenticated?(resource_name)} #{warden.user(resource_name)}"
     if resource
       set_flash_message!(:notice, :signed_in)
       sign_in(resource_name, resource)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,15 @@
+class SessionsController < Devise::SessionsController
+  def create
+    self.resource = warden.authenticate(auth_options)
+    puts "#{auth_options} #{warden.inspect} #{warden.authenticated?(resource_name)} #{warden.user(resource_name)}"
+    if resource
+      set_flash_message!(:notice, :signed_in)
+      sign_in(resource_name, resource)
+      respond_with resource, location: after_sign_in_path_for(resource)
+    else
+      self.resource = resource_class.new(sign_in_params)
+      flash.now[:alert] = t('devise.failure.invalid')
+      render turbo_stream: turbo_stream.update('flash', partial: 'layouts/alert')
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,9 +54,9 @@ Hamers::Application.routes.draw do
 
   root 'static_pages#home'
 
-  devise_for :users
+  devise_for :users, controllers: { sessions: 'sessions' }
   devise_scope :user do
-    get 'signin', to: 'devise/sessions#new', as: "signin"
+    get 'signin', to: 'sessions#new', as: "signin"
   end
 
   resources :users do


### PR DESCRIPTION
Turbo expects either a 422 or 302 redirect on a form submission. 
This does not happen, and we do not want this to happen on signin, so we flash turbo manually