### PR TITLE
Remove 2FA column, remove aspiranten tab and add subtitle

### DIFF
--- a/app/views/users/_table.html.erb
+++ b/app/views/users/_table.html.erb
@@ -6,7 +6,7 @@
           <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead class="bg-gray-100 dark:bg-black">
             <tr>
-              <% %w[Naam Groepen Lichting Citaten Reviews 2FA Inschrijfpercentage].each do |x| %>
+              <% %w[Naam Groepen Lichting Citaten Reviews Inschrijfpercentage].each do |x| %>
                 <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                   <%= x %>
                 </th>
@@ -46,9 +46,6 @@
                   <%= user.reviews.count %>
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                  <%= user.otp_required_for_login? ? "✅" : "🤡" %>
-                </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                   <%= user.drink_ratio.round(0) %> %
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
@@ -66,5 +63,7 @@
     </div>
   </div>
 <% else %>
-  Geen data beschikbaar.
+  <p class="m-2 text-gray-500 dark:text-gray-400">
+    Geen data beschikbaar.
+  </p>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,6 +2,23 @@
   Leden
 <% end %>
 
+<% content_for :subtitle do %>
+  <div class="flex items-center text-sm text-gray-400">
+    <%= heroicon('user', class_name: "flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400") %>
+    <%= @leden.count %> leden
+  </div>
+  <% if @aspiranten.any? %>
+    <div class="flex items-center text-sm text-gray-400">
+      <%= heroicon('user-add', class_name: "flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400") %>
+      <%= @aspiranten.count %> aspirant(en)
+    </div>
+  <% end %>
+  <div class="flex items-center text-sm text-gray-400">
+    <%= heroicon('academic-cap', class_name: "flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400") %>
+    <%= @oudelullen.count %> oud-leden
+  </div>
+<% end %>
+
 <% content_for :options do %>
   <% if current_user&.admin? %>
     <%= link_to new_user_invitation_path, class: button_classes do %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,7 +17,9 @@
       <label for="tabs" class="sr-only">Select a tab</label>
       <select id="tabs" data-action="change->select-tabs#change" data-select-tabs-target="tab" name="tabs" class="block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700 focus:outline-none focus:ring-hamers-red-500 focus:border-hamers-red-500 sm:text-sm rounded-md">
         <option value="0">Leden</option>
-        <option value="1">Aspirant-leden</option>
+        <% if @aspiranten.any? %>
+          <option value="1">Aspirant-leden</option>
+        <% end %>
         <option value="2">Oud-leden</option>
         <option value="3">Overige accounts</option>
       </select>
@@ -29,9 +31,11 @@
           <button href="#" data-action="click->tabs#change" data-tabs-target="tab" class="border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-200 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
             Leden
           </button>
+          <% if @aspiranten.any? %>
           <button data-action="click->tabs#change" data-tabs-target="tab" class="border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-200 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
             Aspirant-leden
           </button>
+          <% end %>
           <button href="#" data-action="click->tabs#change" data-tabs-target="tab" class="border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-200 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
             Oud-leden
           </button>
@@ -46,9 +50,11 @@
   <div class="hidden" data-tabs-target="panel" data-select-tabs-target="panel">
     <%= render "users/table", users: @leden, ratio: true %>
   </div>
+  <% if @aspiranten.any? %>
   <div class="hidden" data-tabs-target="panel" data-select-tabs-target="panel">
     <%= render "users/table", users: @aspiranten %>
   </div>
+  <% end %>
   <div class="hidden" data-tabs-target="panel" data-select-tabs-target="panel">
     <%= render "users/table", users: @oudelullen %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,7 +39,7 @@
           <h4>Gemiste dispuutsborrels</h4>
           <ul class="list-disc list-inside">
             <% @missed_drinks.each do |md| %>
-              <li><%= link_to md.date.strftime("%d-%m-%Y"), md %></li>
+              <li class="text-gray-500 dark:text-gray-400"><%= link_to md.date.strftime("%d-%m-%Y"), md %></li>
             <% end %>
           </ul>
         </div>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -3,7 +3,7 @@ set :environment, ENV['RAILS_ENV']
 set :bundle_command, 'bundle exec'
 set :output, { standard: '/proc/1/fd/1', error: '/proc/1/fd/2' }
 
-job_type :runner, "./cron-executor.sh && :bundle_command rails runner -e :environment ':task' :output"
+job_type :runner, "/webapp/cron-executor.sh && :bundle_command rails runner -e :environment ':task' :output"
 
 
 every :wednesday, at: '1200' do


### PR DESCRIPTION
Did not want to bother with the oud-led(en) since we always have multiple, next to that, I decided just to add `(en)` to aspirant(en) to make it easy.

![Screenshot 2025-05-13 at 13 16 02](https://github.com/user-attachments/assets/beb7af9a-ab38-434a-8a3a-c706c6a1befa)
