### PR TITLE
Fix OTP Issues

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ActiveRecord::Base
   has_many :stickers
   has_many :chugs
   has_many :meetings_attended, through: :attendees, source: :meeting
-  has_many :meetings_chaired, class_name: 'Meeting', inverse_of: :secretary, foreign_key: :chairman_id
+  has_many :meetings_chaired, class_name: 'Meeting', inverse_of: :chairman, foreign_key: :chairman_id
   has_many :meetings_minuted, class_name: 'Meeting', inverse_of: :secretary, foreign_key: :secretary_id
   validates :name, presence: true, length: { maximum: 50 }, uniqueness: true
   validates :email, presence: true, format: Devise.email_regexp, uniqueness: { case_sensitive: false }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ActiveRecord::Base
                              remember_created_at sign_in_count current_sign_in_at last_sign_in_at current_sign_in_ip
                              last_sign_in_ip password_salt confirmation_token confirmed_at confirmation_sent_at
                              remember_token unconfirmed_email failed_attempts unlock_token locked_at weight updated_at remember_token password_digest password password_confirmation
-                             encrypted_otp_secret encrypted_otp_secret_iv encrypted_otp_secret_salt otp_backup_codes otp_secret consumed_timestep]
+                             otp_backup_codes otp_secret consumed_timestep]
   acts_as_paranoid ignore: [:weight]
   serialize :otp_backup_codes, type: Array
   before_save { self.email = email.downcase }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,6 @@ class User < ActiveRecord::Base
   devise :invitable, :two_factor_backupable, # :registerable,
          :recoverable, :rememberable, :trackable, :validatable,
          :lockable, :two_factor_authenticatable,
-         otp_secret_encryption_key: Rails.configuration.OTP_SECRET
   has_paper_trail ignore: %i[drink_ratio encrypted_password reset_password_token reset_password_sent_at
                              remember_created_at sign_in_count current_sign_in_at last_sign_in_at current_sign_in_ip
                              last_sign_in_ip password_salt confirmation_token confirmed_at confirmation_sent_at
@@ -148,75 +147,5 @@ class User < ActiveRecord::Base
 
   def to_s
     name
-  end
-
-  private
-
-  ##
-  # Decrypt and return the `encrypted_otp_secret` attribute which was used in
-  # prior versions of devise-two-factor
-  # @return [String] The decrypted OTP secret
-  def legacy_otp_secret
-    return nil unless self[:encrypted_otp_secret]
-    return nil unless self.class.otp_secret_encryption_key
-
-    hmac_iterations = 2000 # a default set by the Encryptor gem
-    key = self.class.otp_secret_encryption_key
-    salt = Base64.decode64(encrypted_otp_secret_salt)
-    iv = Base64.decode64(encrypted_otp_secret_iv)
-
-    raw_cipher_text = Base64.decode64(encrypted_otp_secret)
-    # The last 16 bytes of the ciphertext are the authentication tag - we use
-    # Galois Counter Mode which is an authenticated encryption mode
-    cipher_text = raw_cipher_text[0..-17]
-    auth_tag =  raw_cipher_text[-16..-1]
-
-    # this algorithm lifted from
-    # https://github.com/attr-encrypted/encryptor/blob/master/lib/encryptor.rb#L54
-
-    # create an OpenSSL object which will decrypt the AES cipher with 256 bit
-    # keys in Galois Counter Mode (GCM). See
-    # https://ruby.github.io/openssl/OpenSSL/Cipher.html
-    cipher = OpenSSL::Cipher.new('aes-256-gcm')
-
-    # tell the cipher we want to decrypt. Symmetric algorithms use a very
-    # similar process for encryption and decryption, hence the same object can
-    # do both.
-    cipher.decrypt
-
-    # Use a Password-Based Key Derivation Function to generate the key actually
-    # used for encryption from the key we got as input.
-    cipher.key = OpenSSL::PKCS5.pbkdf2_hmac_sha1(key, salt, hmac_iterations, cipher.key_len)
-
-    # set the Initialization Vector (IV)
-    cipher.iv = iv
-
-    # The tag must be set after calling Cipher#decrypt, Cipher#key= and
-    # Cipher#iv=, but before calling Cipher#final. After all decryption is
-    # performed, the tag is verified automatically in the call to Cipher#final.
-    #
-    # If the auth_tag does not verify, then #final will raise OpenSSL::Cipher::CipherError
-    cipher.auth_tag = auth_tag
-
-    # auth_data must be set after auth_tag has been set when decrypting See
-    # http://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/Cipher.html#method-i-auth_data-3D
-    # we are not adding any authenticated data but OpenSSL docs say this should
-    # still be called.
-    cipher.auth_data = ''
-
-    # #update is (somewhat confusingly named) the method which actually
-    # performs the decryption on the given chunk of data. Our OTP secret is
-    # short so we only need to call it once.
-    #
-    # It is very important that we call #final because:
-    #
-    # 1. The authentication tag is checked during the call to #final
-    # 2. Block based cipher modes (e.g. CBC) work on fixed size chunks. We need
-    #    to call #final to get it to process the last chunk properly. The output
-    #    of #final should be appended to the decrypted value. This isn't
-    #    required for streaming cipher modes but including it is a best practice
-    #    so that your code will continue to function correctly even if you later
-    #    change to a block cipher mode.
-    cipher.update(cipher_text) + cipher.final
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :invitable, :two_factor_backupable, # :registerable,
          :recoverable, :rememberable, :trackable, :validatable,
-         :lockable, :two_factor_authenticatable,
+         :lockable, :two_factor_authenticatable
   has_paper_trail ignore: %i[drink_ratio encrypted_password reset_password_token reset_password_sent_at
                              remember_created_at sign_in_count current_sign_in_at last_sign_in_at current_sign_in_ip
                              last_sign_in_ip password_salt confirmation_token confirmed_at confirmation_sent_at

--- a/db/migrate/20250724170340_remove_legacy_devise_two_factor_secrets_from_users.rb
+++ b/db/migrate/20250724170340_remove_legacy_devise_two_factor_secrets_from_users.rb
@@ -1,0 +1,7 @@
+class RemoveLegacyDeviseTwoFactorSecretsFromUsers < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :users, :encrypted_otp_secret
+    remove_column :users, :encrypted_otp_secret_iv
+    remove_column :users, :encrypted_otp_secret_salt
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_15_192053) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_24_170340) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", limit: 255, null: false
     t.text "body"
@@ -385,9 +385,6 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_15_192053) do
     t.integer "invitations_count", default: 0
     t.string "phone_number", limit: 255
     t.date "birthday"
-    t.string "encrypted_otp_secret"
-    t.string "encrypted_otp_secret_iv"
-    t.string "encrypted_otp_secret_salt"
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.text "otp_backup_codes"


### PR DESCRIPTION
We never finished the `devise-two-factor` upgrade after https://github.com/DispuutHamers/webapp/pull/610

https://github.com/devise-two-factor/devise-two-factor/blob/main/UPGRADING.md

If this doesn't work, I'm just clearing the `otp_required`, `otp_secret` and `consumed_timestep` for all users, since I am kinda done with this. Every user then has to reset it for themselves next time they log in, better than not being able to log in. 