### PR TITLE
Make `limit` customizable in paginated pages

### DIFF
--- a/app/controllers/beers_controller.rb
+++ b/app/controllers/beers_controller.rb
@@ -13,7 +13,7 @@ class BeersController < ApplicationController
 
   def table
     @search = Beer.ransack(params[:search])
-    @pagy, @beers = pagy(@search.result, items: 16, page: params[:page])
+    @pagy, @beers = pagy(@search.result, limit: params[:limit] || 16, page: params[:page])
   end
 
   # GET /beers/1

--- a/app/controllers/chugtypes_controller.rb
+++ b/app/controllers/chugtypes_controller.rb
@@ -8,7 +8,7 @@ class ChugtypesController < ApplicationController
   end
 
   def show
-    @pagy, @chugs_all_newest = pagy(Chug.newest(@chugtype), items: 10, page: params[:page])
+    @pagy, @chugs_all_newest = pagy(Chug.newest(@chugtype), limit: params[:limit] || 10, page: params[:page])
     @chugs_unique = Chug.unique_not_extern(@chugtype) + Chug.extern(@chugtype)
     @chugs_unique_sorted = @chugs_unique.sort_by { |chug| [chug.time] }
     breadcrumb @chugtype.name, chugtype_path(@chugtype)

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -9,7 +9,7 @@ class StaticPagesController < ApplicationController
     return unless otp_required?
 
     @quote = current_user.quotes.build
-    @pagy, @quotes = pagy(Quote.with_user.ordered, page: params[:page], items: 12) if current_user.can_view_quotes?
+    @pagy, @quotes = pagy(Quote.with_user.ordered, page: params[:page], limit: params[:limit]) if current_user.can_view_quotes?
     @next_event = Event.upcoming.order(date: :asc).first
     @signup = @next_event&.signups&.where(user: current_user)&.first
     @trail = PaperTrail::Version.includes(:item).last(5).reverse
@@ -35,7 +35,7 @@ class StaticPagesController < ApplicationController
   def trail
     @pagy, @trail = pagy(PaperTrail::Version.includes(:item).all.order(created_at: "DESC"),
                          page: params[:page],
-                         items: 20)
+                         limit: params[:limit])
     breadcrumb 'Log', trail_path
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,7 +32,7 @@ class UsersController < ApplicationController
     breadcrumb @user.name, user_path(@user)
 
     @pagy, @quotes = if current_user.can_view_quotes?
-                       pagy(@user.quotes.ordered, items: 25, page: params[:page])
+                       pagy(@user.quotes.ordered, limit: params[:limit] || 25, page: params[:page])
                      else
                        pagy(Quote.where(user_id: 0), page: params[:page])
                      end


### PR DESCRIPTION
Two changes. First, we rename `items` to `limit`. Since https://ddnexus.github.io/pagy/changelog/#version-900 (we're using Pagy 9.3.4), `items` has been renamed to `limit`. This means that since probably a long time the custom limits didn't really work. You can verify this:

  - https://zondersikkel.nl/beers has 20 items per page, where `app/controllers/beers_controller.rb` had `items: 16`.

  - https://zondersikkel.nl/chugtypes/2 has 20 items per page, `chugtypes_controller.rb` has `items: 10`

  - https://zondersikkel.nl/users/14 has 20 quotes per page, `static_pages_controller.rb` has `items: 12`

  - etc

Change 2: make limit customizable. With this change, going to http://localhost:3000/?limit=5 shows only 5 quotes per page. The motivation for this was that it's somewhat burdensome to search for quotes in the past. This way you can just set `?limit=10000` and do Ctrl+F :)